### PR TITLE
Carousel: Update children if different (needed for the Hub

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -8,7 +8,7 @@ import { execCb } from '../funcHandler';
 import { addCarouselToStore, _updateBinder } from '../redux/actions';
 import { LEFT, RIGHT, DOWN, UP, ENTER } from '../keys';
 import { CAROUSEL_TYPE } from '../constants';
-import isEqual from 'lodash/isEqual';
+import { hasDiff } from '../engines/helpers';
 
 class Carousel extends Component {
 
@@ -92,7 +92,7 @@ class Carousel extends Component {
   }
 
   componentWillUpdate({ children }) {
-    if (!isEqual(children, this.props.children)) {
+    if (hasDiff(children, this.props.children)) {
       this.updateState(this.state.cursor, children);
     }
   }

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -8,6 +8,7 @@ import { execCb } from '../funcHandler';
 import { addCarouselToStore, _updateBinder } from '../redux/actions';
 import { LEFT, RIGHT, DOWN, UP, ENTER } from '../keys';
 import { CAROUSEL_TYPE } from '../constants';
+import isEqual from 'lodash/isEqual';
 
 class Carousel extends Component {
 
@@ -91,7 +92,7 @@ class Carousel extends Component {
   }
 
   componentWillUpdate({ children }) {
-    if (this.props.children.length === 0) {
+    if (!isEqual(children, this.props.children)) {
       this.updateState(this.state.cursor, children);
     }
   }


### PR DESCRIPTION
<img width="683" alt="capture d ecran 2016-12-19 a 16 53 43" src="https://cloud.githubusercontent.com/assets/9316820/21319001/beb9d62e-c60b-11e6-9fb7-cde4f1ae2448.png">

In the case the second Carousel need to display different children according to the first Carousel, it won't work with the actual version.

This is a fix to make this work.