### PR TITLE
Remove binder infos from store when unmounted

### DIFF
--- a/src/components/Binder.js
+++ b/src/components/Binder.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { refresh } from '../engines/mosaic';
-import { BINDER_TYPE, C_DOWN, C_LEFT, C_RIGHT, C_UP, NAME } from '../constants';
+import { BINDER_TYPE, C_DOWN, C_LEFT, C_RIGHT, C_UP, NAME, EXIT_STRATEGY_MEMORY, } from '../constants';
 import { block, isBlocked } from '../clock';
 import blocks from '../blocks';
 import { isActive } from '../isActive';
@@ -13,7 +13,8 @@ import {
   _updateBinder,
   addBinderToStore,
   determineNewState,
-  updatePosition
+  updatePosition,
+  removeBinderFromStore,
 } from '../redux/actions';
 import { calculateElSpace, downLimit, hasDiff, rightLimit } from '../engines/helpers';
 
@@ -101,6 +102,11 @@ class Binder extends Component {
       onEnter,
       triggerClick,
     } = this.props;
+
+    if (!this.listenerId) {
+      return;
+    }
+
     const { nextEl } = globalStore.getState()['@@keys'][id];
     if (click
       && triggerClick
@@ -179,7 +185,12 @@ class Binder extends Component {
   }
 
   componentWillUnmount() {
-    removeListener(this.listenerId);
+    this.listenerId = removeListener(this.listenerId);
+
+    const { enterStrategy, id } = this.props;
+    if (enterStrategy !== EXIT_STRATEGY_MEMORY) {
+      removeBinderFromStore(id)
+    }
   }
 
   render() {

--- a/src/components/__spec__/Binder.spec.js
+++ b/src/components/__spec__/Binder.spec.js
@@ -3,6 +3,7 @@ import Binder from '../Binder';
 import { createStore, combineReducers } from 'redux';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
+import { expect } from 'chai';
 import { keyDown, keyUp } from '../../../test/helpers';
 import { keysInit, keysReducer, block, unblock, config } from '../../';
 
@@ -362,5 +363,27 @@ describe('Binder', () => {
 
     binder.unmount();
   }));
+
+  it('should remove binder state when component is unmounted', () => {
+    // Given
+    const binder = mount(<Binder id="batman"/>);
+
+    // When
+    binder.unmount();
+
+    // Then
+    expect(store.getState()['@@keys'].batman).to.equal(undefined);
+  });
+
+  it('should not remove component when enterStrategy is "memory"', () => {
+    // Given
+    const binder = mount(<Binder id="robin" enterStrategy="memory"/>);
+
+    // When
+    binder.unmount();
+
+    // Then
+    expect(store.getState()['@@keys'].robin.id).to.equal('robin');
+  });
 
 });

--- a/src/listener.js
+++ b/src/listener.js
@@ -89,4 +89,5 @@ export function addListener(callback, context) {
 
 export function removeListener(id) {
   keysListeners = keysListeners.filter(listener => listener.id !== id);
+  return null;
 }

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -13,6 +13,7 @@ export const UPDATE_BINDER_STATE = [NAME, '/UPDATE_BINDER_STATE'].join('');
 export const UPDATE_CURRENT = [NAME, '/UPDATE_CURRENT'].join('');
 export const UPDATE_PRESS_STATUS = [NAME, '/UPDATE_PRESS_STATUS'].join('');
 export const RESET_BINDER = [NAME, '/RESET_BINDER'].join('');
+export const REMOVE_BINDER = [NAME, '/REMOVE_BINDER'].join('');
 
 export function addCarouselToStore(props, type) {
   ensureDispatch();
@@ -248,4 +249,12 @@ export function resetFlipFlop(binderId) {
       state: { prevDir: null },
     });
   }
+}
+
+export function removeBinderFromStore(binderId) {
+  ensureDispatch();
+  globalStore.dispatch({
+    type: REMOVE_BINDER,
+    binderId,
+  });
 }

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -6,6 +6,7 @@ import {
   UPDATE_BINDER_SELECTED_KEY,
   UPDATE_CURRENT,
   RESET_BINDER,
+  REMOVE_BINDER
 } from './actions';
 
 const initialKeysSate = {
@@ -47,6 +48,8 @@ export function _keyReducer(state = initialKeysSate, action) {
           nextEl: state[action.binderId].elements.find(e => e.id === action.selectedId),
         },
       };
+    case REMOVE_BINDER:
+      return copyStateWithout(state, action.binderId);
     case UPDATE_BINDER_SELECTED_KEY:
       return {
         ...state,
@@ -78,4 +81,10 @@ export function _keyReducer(state = initialKeysSate, action) {
     default:
       return state;
   }
+}
+
+function copyStateWithout(state, without) {
+  const copy = { ...state };
+  delete copy[without];
+  return copy;
 }


### PR DESCRIPTION
A proposal for removing informations of binder state from redux when unmounting.